### PR TITLE
combined 2 menus into one, add style

### DIFF
--- a/apps/web/pages/Components/Custom/Custom.tsx
+++ b/apps/web/pages/Components/Custom/Custom.tsx
@@ -2,13 +2,13 @@ import React, { useState, useEffect } from 'react'
 // import { InputContext } from '../index';
 import { InputContext } from '../../index'
 
-function Custom({ selected, setNodes, setMarked }: any) {
+function Custom({ selected, setNodes, setMarked, option }: any) {
   const [nodeName, setNodeName] = useState('')
 
   const handleDelNode = () => {
     setNodes((nds) =>
       nds.filter((nd) =>
-        nd.id !== 'dndnode_head' ? nd.id !== selected.id : nds
+        nd.id !== 'node_head' ? nd.id !== selected.id : nds
       )
     )
   }
@@ -41,41 +41,82 @@ function Custom({ selected, setNodes, setMarked }: any) {
 
   const inputRef = React.useContext(InputContext)
 
+
+  //from Sidebar.tsx 
+
+  const onDragStart = (event, nodeType) => {
+    event.dataTransfer.setData('application/reactflow', nodeType)
+    if (option === 'creator') event.dataTransfer.effectAllowed = 'move'
+    else event.dataTransfer.effectAllowed = 'none'
+  }
+
   return (
-    <div className="custom">
-      <div className="description">Custom Styles</div>
-      <h3> Selected Node: {selected === '' ? 'None' : selected.id}</h3>
-      {selected === '' ? null : (
-        <div className="custom-name-input">
-          <label htmlFor="name">Name</label>
-          <input
-            onChange={(e) => setNodeName(e.target.value)}
-            value={nodeName}
-            type="text"
-            name="name"
-            disabled={selected === '' ? true : false}
-            ref={inputRef}
-          />
-          {/* className="opacity-0" */}
-          <div className="custom-menu-buttons">
-            <button
-              className="custom-button hover:bg-red-400"
-              onClick={handleDelNode}
-            >
-              {' '}
-              Delete
-            </button>
-            <button
-              className="custom-button hover:bg-blue-400"
-              onClick={handleMarkdown}
-            >
-              {' '}
-              Markdown
-            </button>
+    <aside>
+      <div className="description">
+        You can drag these nodes to the pane on the right.
+      </div>
+      <div
+        className="dndnode input"
+        onDragStart={(event) => onDragStart(event, 'branch')}
+        draggable
+      >
+        Branch
+      </div>
+
+      <div
+        className="dndnode output"
+        onDragStart={(event) => onDragStart(event, 'leftLeaf')}
+        draggable
+      >
+        Left Leaf
+      </div>
+      <div
+        className="dndnode output"
+        onDragStart={(event) => onDragStart(event, 'rightLeaf')}
+        draggable
+      >
+        Right Leaf
+      </div>
+      {/* <div className="custom"> */}
+      <div className="description">
+        <div className="description"></div>
+        <h3> Selected Node: {selected === '' ? 'None' : selected.id}</h3>
+        {selected === '' ? null : (
+          <div className="custom-name-input">
+            <label htmlFor="name">Name</label>
+            <input
+              onChange={(e) => setNodeName(e.target.value)}
+              value={nodeName}
+              className="pl-2"
+              type="text"
+              name="name"
+              disabled={selected === '' ? true : false}
+              ref={inputRef}
+            />
+            {/* className="opacity-0" */}
+            <div className="custom-menu-buttons">
+              {selected.id === 'node_head' ? (<></>) : (<button
+                className="custom-button hover:bg-blue-400"
+                onClick={handleMarkdown}
+              >
+                {' '}
+                Markdown
+              </button>)}
+              {selected.id === 'node_head' ? (
+                <></>) : (<button
+                  className="custom-button hover:bg-red-400"
+
+                  onClick={handleDelNode}
+                >
+                  {' '}
+                  Delete
+                </button>)}
+
+            </div>
           </div>
-        </div>
-      )}
-    </div>
+        )}
+      </div>
+    </aside >
   )
 }
 

--- a/apps/web/pages/Components/Sidebar/Sidebar.tsx
+++ b/apps/web/pages/Components/Sidebar/Sidebar.tsx
@@ -1,39 +1,39 @@
-import React from 'react'
+// import React from 'react'
 
-export default function Sidebar({ option }) {
-  const onDragStart = (event, nodeType) => {
-    event.dataTransfer.setData('application/reactflow', nodeType)
-    if (option === 'creator') event.dataTransfer.effectAllowed = 'move'
-    else event.dataTransfer.effectAllowed = 'none'
-  }
+// export default function Sidebar({ option }) {
+//   const onDragStart = (event, nodeType) => {
+//     event.dataTransfer.setData('application/reactflow', nodeType)
+//     if (option === 'creator') event.dataTransfer.effectAllowed = 'move'
+//     else event.dataTransfer.effectAllowed = 'none'
+//   }
 
-  return (
-    <aside>
-      <div className="description">
-        You can drag these nodes to the pane on the right.
-      </div>
-      <div
-        className="dndnode"
-        onDragStart={(event) => onDragStart(event, 'branch')}
-        draggable
-      >
-        Branch
-      </div>
+//   return (
+//     <aside>
+//       <div className="description">
+//         You can drag these nodes to the pane on the right.
+//       </div>
+//       <div
+//         className="dndnode"
+//         onDragStart={(event) => onDragStart(event, 'branch')}
+//         draggable
+//       >
+//         Branch
+//       </div>
 
-      <div
-        className="dndnode output"
-        onDragStart={(event) => onDragStart(event, 'leftLeaf')}
-        draggable
-      >
-        Left Leaf
-      </div>
-      <div
-        className="dndnode output"
-        onDragStart={(event) => onDragStart(event, 'rightLeaf')}
-        draggable
-      >
-        Right Leaf
-      </div>
-    </aside>
-  )
-}
+//       <div
+//         className="dndnode output"
+//         onDragStart={(event) => onDragStart(event, 'leftLeaf')}
+//         draggable
+//       >
+//         Left Leaf
+//       </div>
+//       <div
+//         className="dndnode output"
+//         onDragStart={(event) => onDragStart(event, 'rightLeaf')}
+//         draggable
+//       >
+//         Right Leaf
+//       </div>
+//     </aside>
+//   )
+// }

--- a/apps/web/pages/index.css
+++ b/apps/web/pages/index.css
@@ -43,8 +43,7 @@ a {
 }
 
 .dndflow aside .description {
-  @apply mb-3
-  /* margin-bottom: 10px; */;
+  @apply mb-3;
 }
 
 .markdownBG {
@@ -115,7 +114,6 @@ input {
   @apply clear-both m-2 bg-gray-200 p-2 w-24;
 }
 
-
 .dndflow .dndnode {
   @apply h-8 p-1 border-2 border-solid border-black rounded-sm mb-2 flex justify-center items-center cursor-grab
   /* height: 20px;
@@ -130,11 +128,11 @@ input {
 }
 
 .dndflow .dndnode.input {
-  border-color: #0041d0;
+  @apply border-orange-900 rounded-md hover:bg-gray-100;
 }
 
 .dndflow .dndnode.output {
-  border-color: #ff0072;
+  @apply border-green-700 rounded-md hover:bg-gray-100;
 }
 
 .dndflow .reactflow-wrapper {
@@ -157,7 +155,6 @@ input {
   }
 
   .dndflow aside {
-    width: 20%;
-    max-width: 250px;
+    @apply w-1/5 max-w-xs mt-48 border-2 rounded-xl pl-2 pr-4;
   }
 }

--- a/apps/web/pages/index.tsx
+++ b/apps/web/pages/index.tsx
@@ -17,7 +17,7 @@ import ReactFlow, {
 } from 'reactflow'
 import 'reactflow/dist/style.css'
 
-import Sidebar from './Components/Sidebar/Sidebar'
+// import Sidebar from './Components/Sidebar/Sidebar'
 import Custom from './Components/Custom/Custom'
 import Markdown from './Components/Markdown/Markdown'
 import Option from './Components/Option/Option'
@@ -39,7 +39,7 @@ const nodeTypes = {
 
 const initialNodes = [
   {
-    id: 'dndnode_head',
+    id: 'node_head',
     data: { label: 'Root' },
     position: { x: 0, y: 0 },
     type: 'root',
@@ -47,7 +47,7 @@ const initialNodes = [
 ]
 
 let id = 0
-const getId = () => `dndnode_${id++}`
+const getId = () => `node_${id++}`
 
 export const InputContext = createContext(null)
 
@@ -105,7 +105,7 @@ const DnDFlow = () => {
     [reactFlowInstance, setNodes]
   )
 
-  console.log(nodes)
+
 
   return (
     <div className="dndflow" style={{ height: '100vh' }}>
@@ -134,7 +134,7 @@ const DnDFlow = () => {
                 if (option === 'creator') {
                   inputRef.current.focus()
                   inputRef.current.select()
-                  console.log('node: ', node)
+
                 } // setMarked(node)
               }}
               onNodeClick={(event, node) => {
@@ -152,12 +152,13 @@ const DnDFlow = () => {
             <MiniMap />
           </div>
           <Option option={option} setOption={setOption} />
-          <Sidebar option={option} />
+          {/* <Sidebar option={option} /> */}
           {option === 'creator' ? (
             <Custom
               selected={selected}
               setNodes={setNodes}
               setMarked={setMarked}
+              option={option}
             />
           ) : (
             <div></div>


### PR DESCRIPTION
So I combined 2 separate menus into one. Styled it a bit (not much as I believe we would get some design ideas from the designer). Disabled rendering of ‘markdown’ and ‘delete’ buttons when root node is selected since we decided that root node can’t be deleted and markdown is not working for the root node since yesterday (unless we want to fix it).
Also changed node.id to be node_{number} instead of dungeonsanddragonsnode_{number}.

Also note that I left Sidebar.tsx there (it's not used now) in case we would need it but once you approve my PR I'll delete it



